### PR TITLE
Python3 syntax support

### DIFF
--- a/django_mongoengine/forms/field_generator.py
+++ b/django_mongoengine/forms/field_generator.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.core.validators import EMPTY_VALUES, RegexValidator
-from django.utils.encoding import smart_unicode
+from django.utils.encoding import smart_text
 from django.utils.text import capfirst
 try:
     from django.db.models.options import get_verbose_name
@@ -62,7 +62,7 @@ class MongoFormFieldGenerator(object):
     def string_field(self, value):
         if value in EMPTY_VALUES:
             return None
-        return smart_unicode(value)
+        return smart_text(value)
 
     def integer_field(self, value):
         if value in EMPTY_VALUES:

--- a/django_mongoengine/forms/field_generator.py
+++ b/django_mongoengine/forms/field_generator.py
@@ -10,7 +10,7 @@ except ImportError:
 
 from mongoengine import ReferenceField as MongoReferenceField
 
-from fields import MongoCharField, ReferenceField, DocumentMultipleChoiceField, DictField, EmbeddedDocumentField
+from .fields import MongoCharField, ReferenceField, DocumentMultipleChoiceField, DictField, EmbeddedDocumentField
 
 BLANK_CHOICE_DASH = [("", "---------")]
 

--- a/django_mongoengine/forms/fields.py
+++ b/django_mongoengine/forms/fields.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.core.validators import EMPTY_VALUES
 from django.core.exceptions import ValidationError
-from django.utils.encoding import smart_unicode
+from django.utils.encoding import smart_text
 from django.utils.translation import ugettext_lazy as _
 
 from django_mongoengine.utils import force_text
@@ -33,7 +33,7 @@ class MongoCharField(forms.CharField):
     def to_python(self, value):
         if value in EMPTY_VALUES:
             return None
-        return smart_unicode(value)
+        return smart_text(value)
 
 
 class ReferenceField(forms.ChoiceField):
@@ -73,7 +73,7 @@ class ReferenceField(forms.ChoiceField):
         generate the labels for the choices presented by this object. Subclasses
         can override this method to customize the display of the choices.
         """
-        return smart_unicode(obj)
+        return smart_text(obj)
 
     def clean(self, value):
         if value in EMPTY_VALUES and not self.required:

--- a/django_mongoengine/forms/utils.py
+++ b/django_mongoengine/forms/utils.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 from django.forms.fields import Field
 from django.utils import six
 
-from document_options import DocumentMetaWrapper
+from .document_options import DocumentMetaWrapper
 
 
 def patch_document(function, instance):

--- a/django_mongoengine/forms/utils.py
+++ b/django_mongoengine/forms/utils.py
@@ -8,7 +8,7 @@ from document_options import DocumentMetaWrapper
 
 
 def patch_document(function, instance):
-    setattr(instance, function.__name__, new.instancemethod(function, instance, instance.__class__))
+    setattr(instance, function.__name__, function)
 
 
 def init_document_options(document):

--- a/django_mongoengine/forms/utils.py
+++ b/django_mongoengine/forms/utils.py
@@ -1,4 +1,3 @@
-import new
 from collections import OrderedDict
 
 from django.forms.fields import Field

--- a/django_mongoengine/mongo_admin/helpers.py
+++ b/django_mongoengine/mongo_admin/helpers.py
@@ -9,7 +9,7 @@ from django.contrib.admin.helpers import InlineFieldset as DjangoInlineFieldset
 from django.contrib.admin.helpers import AdminField
 from django.core.exceptions import ObjectDoesNotExist
 
-from django.utils.encoding import smart_unicode
+from django.utils.encoding import smart_text
 from django.utils.html import conditional_escape
 from django.utils.safestring import mark_safe
 
@@ -79,7 +79,7 @@ class AdminReadonlyField(DjangoAdminReadonlyField):
                 if boolean:
                     result_repr = _boolean_icon(value)
                 else:
-                    result_repr = smart_unicode(value)
+                    result_repr = smart_text(value)
                     if getattr(attr, "allow_tags", False):
                         result_repr = mark_safe(result_repr)
             else:

--- a/django_mongoengine/mongo_admin/options.py
+++ b/django_mongoengine/mongo_admin/options.py
@@ -674,7 +674,7 @@ class DocumentAdmin(BaseDocumentAdmin):
         actions = OrderedDict(sorted([
             (name, (func, name, desc))
             for func, name, desc in actions
-        ], key=lambda (nn, (f, n, d)): d))
+        ], key=lambda nn_fnd: nn_fnd[1][2]))
 
         return actions
 

--- a/django_mongoengine/mongo_admin/options.py
+++ b/django_mongoengine/mongo_admin/options.py
@@ -1351,7 +1351,7 @@ class DocumentAdmin(BaseDocumentAdmin):
 
         # Populate deleted_objects, a data structure of all related objects that
         # will also be deleted.
-        print "FIXME: Need to delete nested objects."
+        print("FIXME: Need to delete nested objects.")
         #(deleted_objects, perms_needed, protected) = get_deleted_objects(
         #    [obj], opts, request.user, self.admin_site, using)
 

--- a/django_mongoengine/mongo_admin/templatetags/mongoadmintags.py
+++ b/django_mongoengine/mongo_admin/templatetags/mongoadmintags.py
@@ -22,10 +22,10 @@ def check_grappelli(parser, token):
     bits = token.contents.split()
     
     if len(bits) != 3:
-        raise template.TemplateSyntaxError, "'check_grappelli' tag takes exactly two arguments."
+        raise template.TemplateSyntaxError("'check_grappelli' tag takes exactly two arguments.")
     
     if bits[1] != 'as':
-        raise template.TemplateSyntaxError, "The second argument to 'check_grappelli' must be 'as'"
+        raise template.TemplateSyntaxError("The second argument to 'check_grappelli' must be 'as'")
     varname = bits[2]
     
     return CheckGrappelli(varname)

--- a/django_mongoengine/mongo_admin/util.py
+++ b/django_mongoengine/mongo_admin/util.py
@@ -1,4 +1,4 @@
-from django.utils.encoding import smart_unicode, smart_str
+from django.utils.encoding import smart_text, smart_str
 from django.forms.forms import pretty_name
 from django.db.models.fields import FieldDoesNotExist
 from django.utils import formats
@@ -77,7 +77,7 @@ def display_for_field(value, field):
     elif isinstance(field, fields.FloatField):
         return formats.number_format(value)
     else:
-        return smart_unicode(value)
+        return smart_text(value)
 
 
 def help_text_for_field(name, model):
@@ -85,4 +85,4 @@ def help_text_for_field(name, model):
         help_text = model._meta.get_field_by_name(name)[0].help_text
     except FieldDoesNotExist:
         help_text = ""
-    return smart_unicode(help_text, strings_only=True)
+    return smart_text(help_text, strings_only=True)

--- a/django_mongoengine/mongo_admin/validation.py
+++ b/django_mongoengine/mongo_admin/validation.py
@@ -12,7 +12,7 @@ from django_mongoengine.forms.document_options import DocumentMetaWrapper
 from mongoengine.fields import ListField, EmbeddedDocumentField, ReferenceField
 from mongoengine.base import BaseDocument
 
-from options import BaseDocumentAdmin, EmbeddedDocumentAdmin
+from .options import BaseDocumentAdmin, EmbeddedDocumentAdmin
 
 __all__ = ['validate']
 

--- a/django_mongoengine/mongo_admin/views.py
+++ b/django_mongoengine/mongo_admin/views.py
@@ -179,7 +179,7 @@ class DocumentChangeList(ChangeList):
             # Allow certain types of errors to be re-raised as-is so that the
             # caller can treat them in a special way.
             raise
-        except Exception, e:
+        except Exception as e:
             # Every other error is caught with a naked except, because we don't
             # have any other way of validating lookup parameters. They might be
             # invalid if the keyword arguments are incorrect, or if the values

--- a/tests/views/tests.py
+++ b/tests/views/tests.py
@@ -29,7 +29,7 @@ class TestCase(MongoTestCase):
             "slug": "2066",
             "pages": "800",
             "authors": [scott],
-            "pubdate": datetime.datetime(2008, 10, 01)
+            "pubdate": datetime.datetime(2008, 10, 1)
         }).save()
 
         Book(**{
@@ -37,7 +37,7 @@ class TestCase(MongoTestCase):
             "name": "Dreaming in Code",
             "slug": "dreaming-in-code",
             "pages": "300",
-            "pubdate": datetime.datetime(2006, 05, 01)
+            "pubdate": datetime.datetime(2006, 5, 1)
         }).save()
 
         Page(**{


### PR DESCRIPTION
If you're interested, basic modifications for python3 support (don't know if it breaks python2 support).

Can't get the example to be working, stuck with : 
```
  File "/srv/emma/pymodules/django-mongoengine_perso/example/tumblelog/tumblelog/admin.py", line 26, in <module>
    admin.site.register(BlogPost, BlogPostAdmin)
  File "/srv/emma/pymodules/django-mongoengine_perso/django_mongoengine/mongo_admin/sites.py", line 100, in register
    validate(admin_class, model)
  File "/srv/emma/pymodules/django-mongoengine_perso/django_mongoengine/mongo_admin/validation.py", line 24, in validate
    _validate(cls, model)
  File "/srv/emma/pymodules/django-mongoengine_perso/django_mongoengine/mongo_admin/validation.py", line 38, in _validate
    validate_base(cls, model)
  File "/srv/emma/pymodules/django-mongoengine_perso/django_mongoengine/mongo_admin/validation.py", line 315, in validate_base
    "BaseModelForm." % cls.__name__)
django.core.exceptions.ImproperlyConfigured: BlogPostAdmin.form does not inherit from BaseModelForm.
```
Which seems to be related to something not implemented (DocumentModelForm ?).