### PR TITLE
Fix "AttributeError: 'NoneType' object has no attribute 'capitalize'"

### DIFF
--- a/django_mongoengine/forms/field_generator.py
+++ b/django_mongoengine/forms/field_generator.py
@@ -82,7 +82,7 @@ class MongoFormFieldGenerator(object):
     def get_field_help_text(self, field):
         try:
             return field.help_text.capitalize()
-        except:
+        except AttributeError:
             return None
 
     def generate_stringfield(self, field, **kwargs):

--- a/django_mongoengine/forms/field_generator.py
+++ b/django_mongoengine/forms/field_generator.py
@@ -80,8 +80,10 @@ class MongoFormFieldGenerator(object):
         return capfirst(get_verbose_name(field.name))
 
     def get_field_help_text(self, field):
-        if hasattr(field, 'help_text'):
+        try:
             return field.help_text.capitalize()
+        except:
+            return None
 
     def generate_stringfield(self, field, **kwargs):
         form_class = MongoCharField


### PR DESCRIPTION
It can finally start !

This fix is the "pythonic" way to fix this I think (and it avoids countless checks).

Remaining errors : 
```
/srv/emma/pymodules/django-mongoengine/django_mongoengine/views/edit.py:79: RemovedInDjango110Warning: `django_mongoengine.views.edit.EmbeddedFormMixin.get_form` method must define a default value for its `form_class` argument.
  class EmbeddedFormMixin(FormMixin):

/srv/emma/pymodules/django-mongoengine/example/tumblelog/tumblelog/views.py:29: RemovedInDjango110Warning: `tumblelog.views.AddPostView.get_form` method must define a default value for its `form_class` argument.
  class AddPostView(CreateView):

/srv/emma/pymodules/django-mongoengine/example/tumblelog/tumblelog/urls.py:15: RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of django.conf.urls.url() instances instead.
  url(r'^delete/$', DeletePostView.as_view(), name="post_delete")

/srv/emma/pymodules/django-mongoengine/django_mongoengine/mongo_admin/sites.py:244: RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of django.conf.urls.url() instances instead.
  name='app_list')

/srv/emma/pymodules/django-mongoengine/django_mongoengine/mongo_admin/sites.py:265: RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of django.conf.urls.url() instances instead.
  include(model_admin.urls))

/srv/emma/pymodules/django-mongoengine/example/tumblelog/tumblelog/urls.py:27: RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of django.conf.urls.url() instances instead.
  url(r'^(?P<slug>[a-zA-Z0-9-]+)/', include(post_patterns))
```

Also, I can't get Pillow to be recogized : 
```
(pyenv)15:23 emma@dev ~/pymodules/django-mongoengine/example/tumblelog % pip list
Django (1.9.1)
django-bootstrap3 (6.2.2)
django-mongoengine (0.1.1)
Flask (0.10.1)
itsdangerous (0.24)
Jinja2 (2.8)
MarkupSafe (0.23)
mongoengine (0.9.0)
Pillow (2.6.1)
pip (8.0.2)
pymongo (3.2)
setuptools (5.5.1)
Werkzeug (0.11.3)
```
```
  File "/srv/emma/pymodules/django-mongoengine/example/tumblelog/tumblelog/models.py", line 46, in <module>
    class Image(Post):
  File "/srv/emma/pymodules/django-mongoengine/example/tumblelog/tumblelog/models.py", line 47, in Image
    image = fields.ImageField(required=True)
  File "/srv/emma/pyenv/lib/python3.4/site-packages/mongoengine/fields.py", line 1658, in __init__
    raise ImproperlyConfigured("PIL library was not found")
mongoengine.fields.ImproperlyConfigured: PIL library was not found
```
I have to comment the ImageField class line to even try to start the server.