### PR TITLE
Reuse AbstractBaseUser functions correctly

### DIFF
--- a/django_mongoengine/mongo_auth/models.py
+++ b/django_mongoengine/mongo_auth/models.py
@@ -44,8 +44,8 @@ except ImportError:
 
 class BaseUser(object):
 
-    is_anonymous = AbstractBaseUser.is_anonymous
-    is_authenticated = AbstractBaseUser.is_authenticated
+    is_anonymous = AbstractBaseUser.__dict__['is_anonymous']
+    is_authenticated = AbstractBaseUser.__dict__['is_authenticated']
 
 
 class ContentType(document.Document):


### PR DESCRIPTION
Traceback (most recent call last):
...
  File "/usr/local/lib/python2.7/dist-packages/django/contrib/auth/decorators.py", line 22, in _wrapped_view
    if test_func(request.user):
  File "/usr/local/lib/python2.7/dist-packages/django/contrib/auth/decorators.py", line 46, in <lambda>
    lambda u: u.is_authenticated(),
TypeError: unbound method is_authenticated() must be called with AbstractBaseUser instance as first argument (got nothing instead)
