### PR TITLE
Fix mongo_auth and mongo_admin for django 1.10

### DIFF
--- a/django_mongoengine/mongo_admin/management/commands/createmongodbsuperuser.py
+++ b/django_mongoengine/mongo_admin/management/commands/createmongodbsuperuser.py
@@ -6,8 +6,8 @@ import re
 import sys
 from optparse import make_option
 
-from django_mongoengine.mongo_auth import MongoUser
-from django_mongoengine.connection import DEFAULT_CONNECTION_NAME
+from django_mongoengine.mongo_auth.models import MongoUser
+from django_mongoengine.sessions import DEFAULT_CONNECTION_NAME
 from django.core import exceptions
 from django.core.management.base import BaseCommand, CommandError
 from django.utils.translation import ugettext as _
@@ -28,20 +28,24 @@ def is_valid_email(value):
 
 
 class Command(BaseCommand):
-    option_list = BaseCommand.option_list + (
-        make_option('--username', dest='username', default=None,
-            help='Specifies the username for the superuser.'),
-        make_option('--email', dest='email', default=None,
-            help='Specifies the email address for the superuser.'),
-        make_option('--noinput', action='store_false', dest='interactive', default=True,
-            help=('Tells Django to NOT prompt the user for input of any kind. '
-                  'You must use --username and --email with --noinput, and '
-                  'superusers created with --noinput will not be able to log '
-                  'in until they\'re given a valid password.')),
-        make_option('--database', action='store', dest='database',
-            default=DEFAULT_CONNECTION_NAME, help='Specifies the database to use. Default is "default".'),
-    )
     help = 'Used to create a superuser.'
+    
+    def add_arguments(self, parser):
+        """
+        add custom arguments.
+        """
+        parser.add_argument('--username', dest='username', default=None,
+                            help='Specifies the username for the superuser.')
+        parser.add_argument('--email', dest='email', default=None,
+                            help='Specifies the email address for the superuser.')
+        parser.add_argument('--noinput', action='store_false', dest='interactive', default=True,
+                            help=('Tells Django to NOT prompt the user for input of any kind. '
+                                  'You must use --username and --email with --noinput, and '
+                                  'superusers created with --noinput will not be able to log '
+                                  'in until they\'re given a valid password.'))
+        parser.add_argument('--database', action='store', dest='database',
+                            default=DEFAULT_CONNECTION_NAME,
+                            help='Specifies the database to use. Default is "default".')
 
     def handle(self, *args, **options):
         username = options.get('username', None)
@@ -76,7 +80,7 @@ class Command(BaseCommand):
                         input_msg = 'Username'
                         if default_username:
                             input_msg += ' (leave blank to use %r)' % default_username
-                        username = raw_input(input_msg + ': ')
+                        username = input(input_msg + ': ')
                     if default_username and username == '':
                         username = default_username
                     if not RE_VALID_USERNAME.match(username):
@@ -94,7 +98,7 @@ class Command(BaseCommand):
                 # Get an email
                 while 1:
                     if not email:
-                        email = raw_input('E-mail address: ')
+                        email = input('E-mail address: ')
                     try:
                         is_valid_email(email)
                     except exceptions.ValidationError:

--- a/django_mongoengine/mongo_auth/managers.py
+++ b/django_mongoengine/mongo_auth/managers.py
@@ -2,7 +2,8 @@ from importlib import import_module
 
 from django.conf import settings
 from django.contrib.auth.models import UserManager
-from django.db.models import CharField
+from django.db.models import CharField, BooleanField, DateTimeField, DateField
+from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 
 
@@ -66,6 +67,21 @@ class MongoUserManager(UserManager):
             field = CharField(_(name), max_length=30)
             field.contribute_to_class(self.dj_model, name)
 
+        is_staff = BooleanField(_('is_staff'), default=False)
+        is_staff.contribute_to_class(self.dj_model, 'is_staff')
+
+        is_active = BooleanField(_('is_active'), default=False)
+        is_active.contribute_to_class(self.dj_model, 'is_active')
+
+        is_superuser = BooleanField(_('is_superuser'), default=False)
+        is_superuser.contribute_to_class(self.dj_model, 'is_superuser')
+
+        last_login = DateTimeField(_('last_login'), auto_now_add=True)
+        last_login.contribute_to_class(self.dj_model, 'last_login')
+
+        date_joined = DateTimeField(_('date_joined'), auto_now_add=True)
+        date_joined.contribute_to_class(self.dj_model, 'date_joined')
+
 
     def get(self, *args, **kwargs):
         try:
@@ -80,3 +96,23 @@ class MongoUserManager(UserManager):
 
     def get_queryset(self):
         return get_user_document().objects
+
+    def _create_user(self, username, email, password,
+                     is_staff, is_superuser, **extra_fields):
+        """Create (and save) a new user with the given username, password and
+        email address.
+        """
+        now = timezone.now()
+        if not username:
+            raise ValueError('The given username must be set')
+        email = self.normalize_email(email)
+        model = get_user_document()
+        print(self.__dict__)
+        print(self.model.__dict__)
+        user = model(username=username, email=email,
+                          is_staff=is_staff, is_active=True,
+                          is_superuser=is_superuser,
+                          date_joined=now, **extra_fields)
+        user.set_password(password)
+        user.save()
+        return user

--- a/django_mongoengine/mongo_auth/models.py
+++ b/django_mongoengine/mongo_auth/models.py
@@ -279,6 +279,17 @@ class AbstractUser(BaseUser, document.Document):
 
         # Otherwise we need to check the backends.
         return _user_has_perm(self, perm, obj)
+    
+    def has_perms(self, perm_list, obj=None):
+        """
+        Returns True if the user has each of the specified permissions. If
+        object is passed, it checks if the user has all required perms for this
+        object.
+        """
+        for perm in perm_list:
+            if not self.has_perm(perm, obj):
+                return False
+        return True
 
     def has_module_perms(self, app_label):
         """

--- a/django_mongoengine/mongo_auth/models.py
+++ b/django_mongoengine/mongo_auth/models.py
@@ -249,28 +249,6 @@ class AbstractUser(BaseUser, document.Document):
         """
         return check_password(raw_password, self.password)
 
-    @classmethod
-    def create_user(cls, username, password, email=None):
-        """Create (and save) a new user with the given username, password and
-        email address.
-        """
-        now = timezone.now()
-
-        # Normalize the address by lowercasing the domain part of the email
-        # address.
-        if email is not None:
-            try:
-                email_name, domain_part = email.strip().split('@', 1)
-            except ValueError:
-                pass
-            else:
-                email = '@'.join([email_name, domain_part.lower()])
-
-        user = cls(username=username, email=email, date_joined=now)
-        user.set_password(password)
-        user.save()
-        return user
-
     def get_group_permissions(self, obj=None):
         """
         Returns a list of permission strings that this user has through his/her
@@ -349,6 +327,7 @@ class AbstractUser(BaseUser, document.Document):
 
 class User(AbstractUser):
     meta = {'allow_inheritance': True}
+
 
 class MongoUser(BaseUser, models.Model):
     """"

--- a/example/tumblelog/tumblelog/settings.py
+++ b/example/tumblelog/tumblelog/settings.py
@@ -127,8 +127,8 @@ INSTALLED_APPS = (
 
     'django_mongoengine',
     'django_mongoengine.mongo_auth',
-    'django_mongoengine.mongo_admin.sites',
     'django_mongoengine.mongo_admin',
+    'django_mongoengine.mongo_admin.management',
 
     'bootstrap3',
 


### PR DESCRIPTION
This fixes the use of Django's authentication mechanism with django-mongoengine and the creation of admin user with the usual 'createsuperuser' with django 1.10 (and python3).