### PR TITLE
fix example 'comments Field is required and cannot be empty'

### DIFF
--- a/example/tumblelog/tumblelog/models.py
+++ b/example/tumblelog/tumblelog/models.py
@@ -20,7 +20,7 @@ class Post(Document):
     )
     title = fields.StringField(max_length=255)
     slug = fields.StringField(max_length=255, primary_key=True)
-    comments = fields.ListField(fields.EmbeddedDocumentField('Comment'))
+    comments = fields.ListField(fields.EmbeddedDocumentField('Comment'), default=[])
 
     def get_absolute_url(self):
         return reverse('post', kwargs={"slug": self.slug})


### PR DESCRIPTION
when: 

```
create a post in admin panel.
```

bug error:

```
ValidationError (Post.BlogPost:tets) (Field is required and cannot be empty: ['comments'])
```

fix:

set `default=[]` to comments `ListField`.

