### PR TITLE
add Django-fied version of DynamicEmbeddedDocument

### DIFF
--- a/django_mongoengine/__init__.py
+++ b/django_mongoengine/__init__.py
@@ -1,6 +1,6 @@
-from .document import Document, DynamicDocument, EmbeddedDocument
+from .document import Document, DynamicDocument, EmbeddedDocument, DynamicEmbeddedDocument
 from .queryset import QuerySet, QuerySetNoCache
 
-__all__ = ["QuerySet", "QuerySetNoCache", "Document", "DynamicDocument", "EmbeddedDocument"]
+__all__ = ["QuerySet", "QuerySetNoCache", "Document", "DynamicDocument", "EmbeddedDocument", "DynamicEmbeddedDocument"]
 
 default_app_config = 'django_mongoengine.apps.DjangoMongoEngineConfig'

--- a/django_mongoengine/document.py
+++ b/django_mongoengine/document.py
@@ -57,3 +57,7 @@ class DynamicDocument(django_meta(mtc.TopLevelDocumentMetaclass,
 class EmbeddedDocument(django_meta(mtc.DocumentMetaclass,
                                    DjangoFlavor, me.EmbeddedDocument)):
     swap_base = True
+
+class DynamicEmbeddedDocument(django_meta(mtc.DocumentMetaclass,
+                                   DjangoFlavor, me.DynamicEmbeddedDocument)):
+    swap_base = True


### PR DESCRIPTION
I had a need for a DyanmicEmbeddedDocument and needed to add support for that to django-mongoengine.