### PR TITLE
Admin fixes

### DIFF
--- a/django_mongoengine/forms/document_options.py
+++ b/django_mongoengine/forms/document_options.py
@@ -114,8 +114,11 @@ class DocumentMetaWrapper(object):
         return self.model_name
 
     def get_app_label(self):
-        model_module = sys.modules[self.document.__module__]
-        return model_module.__name__.split('.')[-2]
+        if 'app_label' in self._meta:
+            return self._meta['app_label']
+        else:
+            model_module = sys.modules[self.document.__module__]
+            return model_module.__name__.split('.')[-2]
 
     def get_verbose_name(self):
         """

--- a/django_mongoengine/forms/document_options.py
+++ b/django_mongoengine/forms/document_options.py
@@ -53,6 +53,7 @@ class DocumentMetaWrapper(object):
     model_name = None
     verbose_name = None
     has_auto_field = False
+    abstract = False
     object_name = None
     proxy = []
     virtual_fields = []


### PR DESCRIPTION
Fix to use  app_label metadata and default abstract metadata value, needed by the django admin