### PR TITLE
Some default django behavior in admin

### DIFF
--- a/django_mongoengine/fields/djangoflavor.py
+++ b/django_mongoengine/fields/djangoflavor.py
@@ -196,6 +196,11 @@ class DecimalField(MinMaxMixin, DjangoField):
 
 class BooleanField(DjangoField):
 
+    def __init__(self, *args, **kwargs):
+        kwargs['blank'] = True
+
+        super(BooleanField, self).__init__(*args, **kwargs)
+
     def formfield(self, **kwargs):
         # Unlike most fields, BooleanField figures out include_blank from
         # self.null instead of self.blank.
@@ -229,7 +234,6 @@ class ReferenceField(DjangoField):
 
 # TODO: test field.field.choices?
 class ListField(DjangoField):
-
     def formfield(self, **kwargs):
         if self.field.choices:
             defaults = {

--- a/django_mongoengine/mongo_admin/options.py
+++ b/django_mongoengine/mongo_admin/options.py
@@ -499,6 +499,8 @@ class DocumentAdmin(BaseDocumentAdmin):
 
         return queryset, use_distinct
 
+    media = djmod.ModelAdmin.media
+
 
 class InlineDocumentAdmin(BaseDocumentAdmin):
     """
@@ -531,16 +533,7 @@ class InlineDocumentAdmin(BaseDocumentAdmin):
         if self.verbose_name_plural is None:
             self.verbose_name_plural = self.model._meta.verbose_name_plural
 
-    def _media(self):
-        from django.conf import settings
-        js = ['js/jquery.min.js', 'js/jquery.init.js', 'js/inlines.min.js']
-        if self.prepopulated_fields:
-            js.append('js/urlify.js')
-            js.append('js/prepopulate.min.js')
-        if self.filter_vertical or self.filter_horizontal:
-            js.extend(['js/SelectBox.js' , 'js/SelectFilter2.js'])
-        return forms.Media(js=['%s%s' % (settings.ADMIN_MEDIA_PREFIX, url) for url in js])
-    media = property(_media)
+    media = djmod.ModelAdmin.media
 
     def get_formset(self, request, obj=None, **kwargs):
         """Returns a BaseInlineFormSet class for use in admin add/change views."""


### PR DESCRIPTION
- In django, by default boolean fields, the default is to support blank/null and convert it to False.
- Use the media from original django module ( `djmod.ModelAdmin`)